### PR TITLE
hotfix/Startup-Project-Not-Being-Saved-To-Source-Control

### DIFF
--- a/NewsWebsite.sln
+++ b/NewsWebsite.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewsWebsite", "NewsWebsite\NewsWebsite.csproj", "{1E243404-DFB2-4FD3-985C-74E755079518}"
-EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{371BF1E9-6FAB-4CC6-84B0-A1B2B4B73FFF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewsWebsite", "NewsWebsite\NewsWebsite.csproj", "{1E243404-DFB2-4FD3-985C-74E755079518}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataAccess", "DataAccess\DataAccess.csproj", "{F6E13CA2-F8B5-49CF-BC88-FD47AC554BE6}"
 EndProject


### PR DESCRIPTION
Since the "Set as Startup Project" setting is stored in the `.suo` file (which stores other user specific settings) and is not tracked by git, we must change the order of the `docker-compose` project to be at first place in the `.sln` file. (https://stackoverflow.com/questions/694730/why-is-set-as-startup-option-stored-in-the-suo-file-and-not-the-sln-file/1808352#1808352)